### PR TITLE
Fix patterns in zip-excludes.lst

### DIFF
--- a/zip-excludes.lst
+++ b/zip-excludes.lst
@@ -1,3 +1,2 @@
-Aero/
-devel-res/
-
+./Aero/
+./devel-res/


### PR DESCRIPTION
Hi, this is a way to make the exclusion patterns effective (`*/devel-res/` would be possible too in order to match the directory at any level).

The latest pattern syntax and matching algorithm are described [here](https://gitlab.com/flightgear/fgmeta-python/-/blob/next/src/flightgear/meta/aircraft_catalogs/catalog.py?ref_type=heads#L395) (previously, patterns had to start matching the aircraft dir; this is no longer the case; related problems were fixed very recently as shown in [fgmeta-python#3](https://gitlab.com/flightgear/fgmeta-python/-/work_items/3) and [fgmeta-python!57](https://gitlab.com/flightgear/fgmeta-python/-/merge_requests/57), FYI).

`fg-build-catalog` is also in the `flightgear` Python package made from [fmeta-python](https://gitlab.com/flightgear/fgmeta-python), so you could try it at home. :)